### PR TITLE
Fix virtual folders with same origin/source user

### DIFF
--- a/lib/Storage/LazyWrapper.php
+++ b/lib/Storage/LazyWrapper.php
@@ -72,7 +72,6 @@ class LazyWrapper extends Wrapper {
 
 	private function init() {
 		if (!$this->initialized) {
-			$this->initialized = true;
 			try {
 				$this->storage = ($this->sourceFactory)();
 			} catch (NotFoundException $e) {
@@ -87,6 +86,7 @@ class LazyWrapper extends Wrapper {
 				$this->storage = new FailedStorage(['exception' => $e]);
 				$this->cache = new FailedCache();
 			}
+			$this->initialized = true;
 		}
 	}
 


### PR DESCRIPTION
The storage is marked as initialized to early which lead to calls on null when the storage wrapper tries to get the owner of the storage of the source file in https://github.com/icewind1991/virtualfolder/blob/main/lib/Folder/SourceFile.php#L56

Steps to reproduce:
- Create a virtual folder with the same source/target user:
  `occ virtualfolder:create admin admin /virt 18461`
